### PR TITLE
GPS error/status reporting

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -149,7 +149,12 @@ angular.module('almond', ['ionic', 'almond.controllers', 'angularMoment', 'ion-g
         })
       },function(error) {
         deferred.reject("Geolocation API didn't return coordinates :(");
-        console.warn("GPS error: " + error);
+        if(error.code && error.message) {
+          console.warn('GPS error ' + error.code + ": " + error.message);
+        } else {
+            console.warn("GPS error: No error message. Error object below.");
+            console.dir(error);
+        }
       },
       {
         enableHighAccuracy: true,

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -141,6 +141,7 @@ angular.module('almond', ['ionic', 'almond.controllers', 'angularMoment', 'ion-g
     getCoords: function() {
       var deferred = $q.defer();
       navigator.geolocation.getCurrentPosition(function(pos) {
+        $rootScope.locationHealth = 0; // 0 is good, 1 is out of date, 2 is bad
         $rootScope.$broadcast('UserLocation.Update');
         deferred.resolve({
           latitude: pos.coords.latitude,
@@ -149,6 +150,8 @@ angular.module('almond', ['ionic', 'almond.controllers', 'angularMoment', 'ion-g
         })
       },function(error) {
         deferred.reject("Geolocation API didn't return coordinates :(");
+        if(error.code === 3 && $rootScope.userLat) { $rootScope.locationHealth = 1; }
+        else { $rootScope.locationHealth = 2; }
         if(error.code && error.message) {
           console.warn('GPS error ' + error.code + ": " + error.message);
         } else {

--- a/www/templates/start.html
+++ b/www/templates/start.html
@@ -21,4 +21,13 @@
 
     </div>
   </ion-content>
+  <div ng-if="$root.locationHealth === 0" class="bar bar-footer bar-balanced">
+    <div class="title">GPS OK</div>
+  </div>
+  <div ng-if="$root.locationHealth === 1" class="bar bar-footer bar-energized">
+    <div class="title">GPS location out of date</div>
+  </div>
+  <div ng-if="$root.locationHealth === 2" class="bar bar-footer bar-assertive">
+    <div class="title">GPS location not available</div>
+  </div>
 </ion-view>


### PR DESCRIPTION
- The specificity of GPS-related `console.warn()`s has been improved.
- `$rootScope` now has a `locationHealth` property. It has three potential states:
  - `0`: the GPS location is current.
  - `1`: the GPS location is out of date, but present.
  - `2`: the GPS location is not available.
- The Start view now has an indicator for the current location health.