### PR TITLE
Polyline-based route overviews

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -30,7 +30,7 @@
     <script src="js/controllers.js"></script>
 
     <!-- google maps js -->
-    <script src="http://maps.googleapis.com/maps/api/js?key=AIzaSyB-MG97GSsDQoHnO_bX4Gdu7hhlTv8OB1c&amp;sensor=true"></script>
+    <script src="http://maps.googleapis.com/maps/api/js?key=AIzaSyB-MG97GSsDQoHnO_bX4Gdu7hhlTv8OB1c&amp;sensor=true&libraries=geometry"></script>
 
     <!-- jquery -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>

--- a/www/index.html
+++ b/www/index.html
@@ -30,7 +30,7 @@
     <script src="js/controllers.js"></script>
 
     <!-- google maps js -->
-    <script src="http://maps.googleapis.com/maps/api/js?key=AIzaSyB-MG97GSsDQoHnO_bX4Gdu7hhlTv8OB1c&amp;sensor=true&libraries=geometry"></script>
+    <script src="http://maps.googleapis.com/maps/api/js?key=AIzaSyB-MG97GSsDQoHnO_bX4Gdu7hhlTv8OB1c&amp;sensor=true&amp;libraries=geometry"></script>
 
     <!-- jquery -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -228,23 +228,26 @@ angular.module('almond', ['ionic', 'almond.controllers', 'angularMoment', 'ion-g
     return map;
   };
 
-  var drawRoute = function(map,sLat,sLng,endStr) {
-    var directionsService = new google.maps.DirectionsService();
-    var start = new google.maps.LatLng(sLat, sLng);
-    var end = endStr;
-    var directionsDisplay = new google.maps.DirectionsRenderer();// also, constructor can get "DirectionsRendererOptions" object
-    directionsDisplay.setMap(map); // map should be already initialized.
+  var drawRoute = function(map,routeData) {
+    var route = new google.maps.Polyline({
+      // path:google.maps.geometry.encoding.decodePath(poly),
+      strokeColor: "#0000FF",
+      strokeOpacity: 1.0,
+      strokeWeight: 2
+    }); 
 
-    var directionsService = new google.maps.DirectionsService(); 
-    directionsService.route({
-      origin : start,
-      destination : end,
-      travelMode : google.maps.TravelMode.DRIVING
-    }, function(response, status) {
-      if (status == google.maps.DirectionsStatus.OK) {
-        directionsDisplay.setDirections(response);
-      }
-    });
+    var bounds = new google.maps.LatLngBounds();
+
+
+    var steps = routeData.directions;
+    for (i=0;i<steps.length;i++) {
+      route.getPath().push(steps[i].polyline.points);
+      console.log("step " + i + ":" + steps[i].polyline.points)
+      // bounds.extend(steps[i].polyline);
+    }
+
+    map.fitBounds(bounds);
+    route.setMap(map);
   };
 
   var updateUserLocation = function(map,lat,lng,accuracy,userMarker) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -213,41 +213,96 @@ angular.module('almond', ['ionic', 'almond.controllers', 'angularMoment', 'ion-g
   };
 })
 
-.service('mapService',function(){
+// This is adapted from the implementation in Project-OSRM
+// https://github.com/DennisOSRM/Project-OSRM-Web/blob/master/WebContent/routing/OSRM.RoutingGeometry.js
+.service('polylineUtilityService',function() {
+ var decode = function(str, precision) {
+   var index = 0,
+       lat = 0,
+       lng = 0,
+       coordinates = [],
+       shift = 0,
+       result = 0,
+       byte = null,
+       latitude_change,
+       longitude_change,
+       factor = Math.pow(10, precision || 5);
+
+   // Coordinates have variable length when encoded, so just keep
+   // track of whether we've hit the end of the string. In each
+   // loop iteration, a single coordinate is decoded.
+   while (index < str.length) {
+       // Reset shift, result, and byte
+       byte = null;
+       shift = 0;
+       result = 0;
+       do {
+           byte = str.charCodeAt(index++) - 63;
+           result |= (byte & 0x1f) << shift;
+           shift += 5;
+       } while (byte >= 0x20);
+       latitude_change = ((result & 1) ? ~(result >> 1) : (result >> 1));
+       shift = result = 0;
+       do {
+           byte = str.charCodeAt(index++) - 63;
+           result |= (byte & 0x1f) << shift;
+           shift += 5;
+       } while (byte >= 0x20);
+       longitude_change = ((result & 1) ? ~(result >> 1) : (result >> 1));
+       lat += latitude_change;
+       lng += longitude_change;
+       coordinates.push([lat / factor, lng / factor]);
+   }
+   return coordinates;
+ };
+ return {
+  decode: decode
+ }
+})
+
+.service('mapService',function(polylineUtilityService){
   var accuracyCircle;
   var create = function(id,lat,lng) {
     lat = lat || 37.7483;
     lng = lng || -122.4367;
-    var map = new google.maps.Map(document.getElementById(id), {
+    var mapOptions = {
       center: new google.maps.LatLng(lat,lng),
       zoom: 12,
       mapTypeId: google.maps.MapTypeId.ROADMAP,
       disableDefaultUI: true,
       styles: [{ featureType: "poi", elementType: "labels", stylers: [{ visibility: "off" }]}]
-    });
+    };
+    var map = new google.maps.Map(document.getElementById(id), mapOptions);
     return map;
   };
 
   var drawRoute = function(map,routeData) {
-    var route = new google.maps.Polyline({
-      // path:google.maps.geometry.encoding.decodePath(poly),
+
+    // var bounds = new google.maps.LatLngBounds();
+
+    var points = [];
+
+    var steps = routeData.directions, decoded;
+    for (i=0;i<steps.length;i++) {
+      decoded = polylineUtilityService.decode(steps[i].polyline.points);
+      for (var j = 0; j < decoded.length; j++) {
+        points.push(new google.maps.LatLng(decoded[j][0],decoded[j][1]));
+        console.log("step " + i + ":" + steps[i].polyline.points)
+      };
+      // bounds.extend(new google.maps.LatLng(decoded[0],decoded[1]));
+    }
+
+    var options = {
+      path:points,
       strokeColor: "#0000FF",
       strokeOpacity: 1.0,
       strokeWeight: 2
-    }); 
+    };
 
-    var bounds = new google.maps.LatLngBounds();
+    var route = new google.maps.Polyline(options); 
 
-
-    var steps = routeData.directions;
-    for (i=0;i<steps.length;i++) {
-      route.getPath().push(steps[i].polyline.points);
-      console.log("step " + i + ":" + steps[i].polyline.points)
-      // bounds.extend(steps[i].polyline);
-    }
-
-    map.fitBounds(bounds);
-    route.setMap(map);
+    // map.fitBounds(bounds);
+    return route;
   };
 
   var updateUserLocation = function(map,lat,lng,accuracy,userMarker) {
@@ -287,4 +342,5 @@ angular.module('almond', ['ionic', 'almond.controllers', 'angularMoment', 'ion-g
     drawRoute: drawRoute
   }
 })
+
 ;

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -153,12 +153,16 @@ angular.module('almond.controllers', [])
 
   var map = mapService.create('map');
 
+  google.maps.event.addListenerOnce(map, 'idle', function(){
+    var route = mapService.drawRoute(map,$scope.data);
+    route.setMap(map);
+  });
+
   $scope.$on('UserLocation.Update',function(){
     userMarker = mapService.updateUserLocation(map,$rootScope.userLat,$rootScope.userLong,$rootScope.userAccuracy, userMarker);
   })
 
 
-  mapService.drawRoute(map,$scope.data);
 })
 
 .controller('SettingsCtrl', function($scope) {

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -135,11 +135,12 @@ angular.module('almond.controllers', [])
 
 .controller('TravelModeCtrl', function($scope,$stateParams,$rootScope, destinationService, mapService) {
   $scope.activeTab = 'directions';
-  var userMarker;
+  var userMarker, route;
   console.log("TravelModeCtrl says hi");
   var deregister = $scope.$on('TravelModes.Data', function(e,data,i,j) {
     $scope.data = data.data.results[i][j];
     console.log("Got data from event")
+    console.dir($scope.data)
   })
   $rootScope.$broadcast('TravelMode.ReadyforData');
   deregister();
@@ -157,7 +158,7 @@ angular.module('almond.controllers', [])
   })
 
 
-  mapService.drawRoute(map,$rootScope.userLat,$rootScope.userLong,$scope.destination.formatted_address);
+  mapService.drawRoute(map,$scope.data);
 })
 
 .controller('SettingsCtrl', function($scope) {


### PR DESCRIPTION
# We did it! 🎉

- `travelMode`'s Map tab now shows a blue polyline of *the same route* described in the Directions tab!
- There's a new service called `polylineUtilityService`. It has a `decode` function that takes in encoded polylines and returns an array of lat/longs (`number`s, not Google `LatLng` pairs).
  - ex: `goseFfpdjV|Da@` becomes `[[ 37.7882, -122.41684 ], [ 37.78725, -122.41667 ]]`